### PR TITLE
Sync with solid/solid-auth-client (access_token need not be first parameter.)

### DIFF
--- a/src/webid-oidc.js
+++ b/src/webid-oidc.js
@@ -34,7 +34,7 @@ export async function currentSession(
       return null
     }
     const url = currentUrl()
-    if (!url || !url.includes('#access_token=')) {
+    if (!/#(.*&)?access_token=/.test(url)) {
       return null
     }
     const storeData = await getData(storage)


### PR DESCRIPTION
Fixes #80.